### PR TITLE
Mongo uri changes + Refactor of javascript to store waypoints and attractions in retrievable variables.

### DIFF
--- a/app/assets/javascripts/attraction.js
+++ b/app/assets/javascripts/attraction.js
@@ -1,34 +1,45 @@
-var Attraction = function(attraction, marker, route){
-  this.attraction = attraction,
-  this.marker = marker,
-  this.route = route,
+var App = App || {};
+App.Waypoints = []
 
+App.Attraction = function(attrData){
+  this.attrData = attrData;
   this.init();
 }
 
-Attraction.prototype.init = function(){
-  this.loadAttraction();
-  this.setListeners();
+App.Attraction.prototype.init = function(){
+  this.createMarker()
+  this.createListItem();
 }
 
-Attraction.prototype.loadAttraction = function(){
-  var $attractionInfo = $(this.buildAttractionInfo());
+App.Attraction.prototype.createMarker = function() {
+  var latitude = this.attrData.longlat.coordinates[1];
+  var longitude = this.attrData.longlat.coordinates[0];
+  var coords = new google.maps.LatLng(latitude, longitude);
 
-  $attractionInfo.data('attraction', this);
+  this.marker = new MarkerObject(coords, this);
+}
 
-  $('#attraction-list').append($attractionInfo);
-};
+App.Attraction.prototype.createListItem = function() {
+    // contruct the li
+    this.$listItem = $(this.buildListItem());
 
-Attraction.prototype.buildAttractionInfo = function() {
+    // apend to the end of the list
+    $('#attraction-list').append(this.$listItem);
+
+    // listen for clicks
+    this.setListItemListeners();
+}
+
+App.Attraction.prototype.buildListItem = function() {
 
   var item = ['<li id="attraction',
-          this.attraction._id,
+          this.attrData._id,
           '">',
-          this.attraction.name,
+          this.attrData.name,
           '<a href="#"',
           '>',
           '<button id="add',
-          this.attraction._id,
+          this.attrData._id,
           '" class="add-button">Add to Trip</button>',
           '</li>'
          ].join('');
@@ -36,41 +47,58 @@ Attraction.prototype.buildAttractionInfo = function() {
   return item;
 }
 
-Attraction.prototype.setListeners = function(){
-  var thisAttraction = this
+App.Attraction.prototype.setListItemListeners = function(){
+  var self = this;
 
-
-  $('#attraction-list').on('click', '#attraction' + this.attraction._id, function(event){
+  // Set a listener that will handle list item clicks
+  $(this.$listItem).on('click', function(event){
     event.preventDefault();
-    thisAttraction.setListInteraction();
-  })
+
+    $('li.active').removeClass('active')
+    self.$listItem.addClass('active')
+  });
+
+  // Set a listener that will handle list item "add button "
+  $(this.$listItem).on('click', '.add-button', function(event) {
+    event.preventDefault();
+
+    self.$listItem.addClass('saved')
+    self.setAsWaypoint();
+  });
 }
 
+App.Attraction.prototype.onMarkerClicked = function() {
+  // move the list item to top
+  this.$listItem.remove();
+  $('#attraction-list').prepend(this.$listItem);
 
-Attraction.prototype.setListInteraction = function(){
-  var listItem = $('#attraction' + this.attraction._id);
-  $('#attraction-list').prepend(listItem);
+  // set clicked list-item to active state
+  $('li.active').removeClass('active')
+  this.$listItem.addClass('active')
+  // this.$listItem.css('background-color', 'purple')
 }
 
-Attraction.prototype.setAsWaypoint = function(){
+App.Attraction.prototype.setAsWaypoint = function(){
 
-  var lng = this.attraction.longlat.coordinates[0]
-  var lat = this.attraction.longlat.coordinates[1]
+  var lng = this.attrData.longlat.coordinates[0]
+  var lat = this.attrData.longlat.coordinates[1]
   var coords = new google.maps.LatLng(lat, lng)
 
-  this.route.waypts.push({
+  route.waypts.push({
         location: coords,
         stopover: true});
 
-  this.route.calculateRoute();
+  route.calculateRoute();
+
+  App.Waypoints.push(this);
 }
 
-$(function() {
-  $('#attraction-list').on('click', '.add-button', function(event){
-    event.preventDefault();
+// $(function() {
+//   $('#attraction-list').on('click', '.add-button', function(event){
+//     event.preventDefault();
 
-    var thisAttraction = $(this).closest("li").data("attraction");
-    thisAttraction.setAsWaypoint();
-  });
+//     var thisAttraction = $(this).closest("li").data("attraction");
+//     thisAttraction.setAsWaypoint();
+//   });
 
-});
+// });

--- a/app/assets/javascripts/attractions.js
+++ b/app/assets/javascripts/attractions.js
@@ -1,0 +1,29 @@
+var App = App || {};
+
+App.AttractionCollection = { items: [] };
+
+// check if the attraction is already added to attractions (by checking id)
+App.AttractionCollection.contains = function(newAttraction) {
+  var contains = false
+  this.items.forEach(function(existingAttraction) {
+    new_ = newAttraction
+    existing_ = existingAttraction
+
+    if (newAttraction._id == existingAttraction.attrData._id) {
+      contains = true;
+    }
+  })
+  return contains;
+}
+
+
+App.AttractionCollection.add = function(attractions) {
+  var self = this;
+  newAttraction = attractions[0]
+  attractions.forEach(function(newAttraction) {
+    // only add the attraction if it isn't yet added
+    if (!self.contains(newAttraction)) {
+      self.items.push(new App.Attraction(newAttraction));
+    }
+  });
+}

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -106,8 +106,7 @@ Polygon.prototype.searchWithin = function(polygon){
     data: JSON.stringify(polygon),
 })
   .success(function(response){
-    markerCollection = new MarkerCollection(response.attractions);
-    markerCollection.loadMarkers()
+    App.AttractionCollection.add(response.attractions);
   })
 }
 
@@ -145,6 +144,7 @@ Drawer.prototype.draw = function(geoJsonObject){
   this.bufferedPolygon.setMap(mapObject.map);
 
 }
+
 
 //------------Markers----------------
 

--- a/app/assets/javascripts/marker.js
+++ b/app/assets/javascripts/marker.js
@@ -6,35 +6,27 @@ var MarkerObject = function(coords, associatedAttraction){
     map: mapObject.map,
     zIndex: nextZIndex(),
     icon: this.defaultIcon
-  }),
+  });
 
-  this.associatedAttraction = associatedAttraction || new Attraction(),
+  this.associatedAttraction = associatedAttraction;
   this.listenForUserInteraction();
 };
 
 MarkerObject.prototype.listenForUserInteraction = function(){
-  var thisMarker = this;
-  var thisAttraction = thisMarker.associatedAttraction;
+  var markerObject = this;
+  // var thisAttraction = thisMarker.associatedAttraction;
 
-  google.maps.event.addListener(thisMarker.marker, 'click', function(){
+  google.maps.event.addListener(markerObject.marker, 'click', function() {
 
-    var thisListItem = $('#attraction' + thisAttraction._id);
+    // Send a callback to the attraction object that this marker has been clicked
+    markerObject.associatedAttraction.onMarkerClicked();
 
-    thisMarker.changeListItemBackgroundColor(thisListItem)
-    thisMarker.changeMarkerColor();
+    // Change the marker color
+    markerObject.changeMarkerColor();
 
-    $('#attraction-list').prepend(thisListItem);
+
   });
 };
-
-MarkerObject.prototype.changeListItemBackgroundColor = function(thisListItem){
-  if (typeof LAST_MARKER_CLICKED !== 'string') {
-    var lastAttraction = LAST_MARKER_CLICKED.associatedAttraction;
-    var lastListItem = $('#attraction' + lastAttraction._id);
-    lastListItem.css('background-color', 'white');
-  }
-  thisListItem.css('background-color', 'purple');
-}
 
 MarkerObject.prototype.changeMarkerColor = function(){
 
@@ -48,31 +40,10 @@ MarkerObject.prototype.changeMarkerColor = function(){
   this.marker.setZIndex(nextZIndex());
 };
 
-var MarkerCollection = function(attractions){
-  this.attractions = attractions;
-};
-
-MarkerCollection.prototype.loadMarkers = function(){
-  var thisCollection = this;
-    $.each(this.attractions, function(i,item){
-      thisCollection.loadMarker(item);
-    });
-  };
-
-MarkerCollection.prototype.loadMarker = function(attraction){
-
-  var latitude = attraction.longlat.coordinates[1];
-  var longitude = attraction.longlat.coordinates[0];
-  var coords = new google.maps.LatLng(latitude, longitude);
-
-  var marker = new MarkerObject(coords, attraction);
-  new Attraction(attraction, marker, route);
-};
-
 window.zindex = 0;
 
 function nextZIndex() {
   return window.zindex += 1;
 }
 
-var LAST_MARKER_CLICKED = 'set me!';
+var LAST_MARKER_CLICKED = 'Set me!';

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -75,7 +75,7 @@ test:
 production:
   sessions:
     default:
-      uri: <%= ENV['MONGOHQ_URL'] %>
+      uri: <%= ENV['MONGOLAB_URI'] %>
       options:
         consistency: :strong
         max_retries: 1

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -77,7 +77,6 @@ production:
     default:
       uri: <%= ENV['MONGOLAB_URI'] %>
       options:
-        consistency: :strong
         max_retries: 1
         retry_interval: 0
   options:


### PR DESCRIPTION
Added a way to persist a list of all attractions already added. This allows us to not add the same attraction twice. I also wrapped every attraction in an Attration object, which stores the original attraction data in attrData. The attraction object also has a reference to its marker (this.marker) and list item DOM element (this.)